### PR TITLE
Add correct numba version to the installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numba==0.48
 librosa
 mir_eval
 visdom


### PR DESCRIPTION
seems like numba removed the decorators module with version 0.50.
This breaks the current code.
See in: https://github.com/librosa/librosa/issues/1160